### PR TITLE
Fixed a dangling pointer compilation warning [-Wdangling-gsl]

### DIFF
--- a/Chapter06/tinylang/lib/CodeGen/CGTBAA.cpp
+++ b/Chapter06/tinylang/lib/CodeGen/CGTBAA.cpp
@@ -70,7 +70,7 @@ llvm::MDNode *CGTBAA::getTypeInfo(TypeDeclaration *Ty) {
       Fields.emplace_back(getTypeInfo(F.getType()), Offset);
       ++Idx;
     }
-    StringRef Name = CGM.mangleName(Record);
+    std::string Name = CGM.mangleName(Record);
     return createStructTypeNode(Record, Name, Fields);
   }
   return nullptr;

--- a/Chapter07/tinylang/lib/CodeGen/CGTBAA.cpp
+++ b/Chapter07/tinylang/lib/CodeGen/CGTBAA.cpp
@@ -65,7 +65,7 @@ llvm::MDNode *CGTBAA::getTypeInfo(TypeDeclaration *Ty) {
       Fields.emplace_back(getTypeInfo(F.getType()), Offset);
       ++Idx;
     }
-    StringRef Name = CGM.mangleName(Record);
+    std::string Name = CGM.mangleName(Record);
     return createStructTypeNode(Record, Name, Fields);
   }
   return nullptr;

--- a/Chapter07/tinylang2/lib/CodeGen/CGTBAA.cpp
+++ b/Chapter07/tinylang2/lib/CodeGen/CGTBAA.cpp
@@ -65,7 +65,7 @@ llvm::MDNode *CGTBAA::getTypeInfo(TypeDeclaration *Ty) {
       Fields.emplace_back(getTypeInfo(F.getType()), Offset);
       ++Idx;
     }
-    StringRef Name = CGM.mangleName(Record);
+    std::string Name = CGM.mangleName(Record);
     return createStructTypeNode(Record, Name, Fields);
   }
   return nullptr;


### PR DESCRIPTION
This commit prevents accessing invalid memory.
Full warning message (cmake version 3.28.1):
Chapter07/tinylang/lib/CodeGen/CGTBAA.cpp:68:22: warning: object backing the pointer will be destroyed at the end of the full-expression [-Wdangling-gsl]
    StringRef Name = CGM.mangleName(Record);
                     ^~~~~~~~~~~~~~~~~~~~~~